### PR TITLE
Unit tests + exposing full api

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,3 +25,8 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.7"
 maturin = "^1.3.2"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -4,6 +4,27 @@ use ::plsfix::{ExplainedText, ExplanationStep, Normalization, TextFixerConfig};
 use pyo3::prelude::*;
 
 #[pyclass]
+#[derive(Debug, Clone, Copy)]
+pub enum PyNormalization {
+    NFC,
+    NFKC,
+    NFD,
+    NFKD,
+}
+
+impl From<PyNormalization> for Normalization {
+    fn from(norm: PyNormalization) -> Self {
+        match norm {
+            PyNormalization::NFC => Normalization::NFC,
+            PyNormalization::NFKC => Normalization::NFKC,
+            PyNormalization::NFD => Normalization::NFD,
+            PyNormalization::NFKD => Normalization::NFKD,
+        }
+    }
+}
+
+
+#[pyclass]
 #[derive(Debug, Clone)]
 pub struct PyTextFixerConfig {
     pub unescape_html: Option<bool>,
@@ -18,8 +39,62 @@ pub struct PyTextFixerConfig {
     pub uncurl_quotes: bool,
     pub fix_line_breaks: bool,
     pub remove_control_chars: bool,
-    pub normalization: Option<Normalization>,
+    pub normalization: Option<PyNormalization>,
     pub max_decode_length: i32,
+}
+
+#[pymethods]
+impl PyTextFixerConfig {
+    #[new]
+    #[pyo3(signature = (
+        unescape_html=None,
+        remove_terminal_escapes=true,
+        fix_encoding=true,
+        restore_byte_a0=true,
+        replace_lossy_sequences=true,
+        decode_inconsistent_utf8=true,
+        fix_c1_controls=true,
+        fix_latin_ligatures=true,
+        fix_character_width=true,
+        uncurl_quotes=true,
+        fix_line_breaks=true,
+        remove_control_chars=true,
+        normalization=None,
+        max_decode_length=1000000
+    ))]
+    pub fn new(
+        unescape_html: Option<bool>,
+        remove_terminal_escapes: bool,
+        fix_encoding: bool,
+        restore_byte_a0: bool,
+        replace_lossy_sequences: bool,
+        decode_inconsistent_utf8: bool,
+        fix_c1_controls: bool,
+        fix_latin_ligatures: bool,
+        fix_character_width: bool,
+        uncurl_quotes: bool,
+        fix_line_breaks: bool,
+        remove_control_chars: bool,
+        normalization: Option<PyNormalization>,
+        max_decode_length: i32,
+    ) -> Self {
+        PyTextFixerConfig {
+            unescape_html,
+            remove_terminal_escapes,
+            fix_encoding,
+            restore_byte_a0,
+            replace_lossy_sequences,
+            decode_inconsistent_utf8,
+            fix_c1_controls,
+            fix_latin_ligatures,
+            fix_character_width,
+            uncurl_quotes,
+            fix_line_breaks,
+            remove_control_chars,
+            normalization,
+            max_decode_length,
+        }
+    }
 }
 
 #[pyclass]
@@ -71,7 +146,7 @@ impl From<PyTextFixerConfig> for TextFixerConfig {
             uncurl_quotes: config.uncurl_quotes,
             fix_line_breaks: config.fix_line_breaks,
             remove_control_chars: config.remove_control_chars,
-            normalization: config.normalization,
+            normalization: config.normalization.map(|n| n.into()),
             max_decode_length: config.max_decode_length,
         }
     }
@@ -136,5 +211,9 @@ pub fn fix_and_explain(
 fn plsfix(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(fix_text, m)?)?;
     m.add_function(wrap_pyfunction!(fix_and_explain, m)?)?;
+    m.add_class::<PyTextFixerConfig>()?;
+    m.add_class::<PyExplainedText>()?;
+    m.add_class::<PyExplanationStep>()?;
+    m.add_class::<PyNormalization>()?;
     Ok(())
 }

--- a/python/tests/test-cases/README.md
+++ b/python/tests/test-cases/README.md
@@ -1,0 +1,22 @@
+NOTE: this was copied over from ftfy. The unit tests are mostly the same, just edited to use plsfix. Some of the tests were not moved over because they tested other features of ftfy (like the cli)
+
+# ftfy test cases
+
+This directory contains JSON files with test cases for ftfy. Many of them are real mojibake found in the wild, such as by listening to the Twitter firehose (when that existed), searching through the OSCAR web crawl, or in issue reports from users.
+
+Cases labeled "synthetic" were not found in the wild, but were instead constructed to test a particular edge case.
+
+Cases labeled "negative" are not mojibake but look lke they could be. We're testing that ftfy does not alter the text (except for its usual processing such as un-curling quotes).
+
+`known-failures.json` contains cases that we would do better at with an improved heuristic. Most of these are false negatives, where ftfy does not figure out how to fix the text. ftfy aims to have no false positives, but there is one synthetic false positive in `known-failures.json`.
+
+## Structure of a test case
+
+A test case contains the following fields:
+
+- `label`: A description of the test case, shown when pytest runs in verbose mode.
+- `comment`: Further details on the test case because JSON doesn't have comments.
+- `original`: The text to run through ftfy.
+- `fixed-encoding` (optional): the expected result of `ftfy.fix_encoding(original)`. If unspecified, uses the value from `fixed`.
+- `fixed`: the expected result of `ftfy.fix_text(original)`.
+- `expect`: "pass" for test cases that should pass, or "fail" for known failures.

--- a/python/tests/test-cases/in-the-wild.json
+++ b/python/tests/test-cases/in-the-wild.json
@@ -1,0 +1,451 @@
+[
+    {
+        "label": "Low-codepoint emoji",
+        "comment": "From the ancient era before widespread emoji support on Twitter",
+        "original": "He's Justinâ\u009d¤",
+        "fixed": "He's Justin❤",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / MacRoman mix-up about smurfs",
+        "original": "Le Schtroumpf Docteur conseille g√¢teaux et baies schtroumpfantes pour un r√©gime √©quilibr√©.",
+        "fixed": "Le Schtroumpf Docteur conseille gâteaux et baies schtroumpfantes pour un régime équilibré.",
+        "expect": "pass"
+    },
+    {
+        "label": "Checkmark that almost looks okay as mojibake",
+        "original": "âœ” No problems",
+        "fixed": "✔ No problems",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1251 Russian mixup about futbol",
+        "original": "РґРѕСЂРѕРіРµ Р\u0098Р·-РїРѕРґ #С„СѓС‚Р±РѕР»",
+        "fixed": "дороге Из-под #футбол",
+        "expect": "pass"
+    },
+    {
+        "label": "Latin-1 / Windows-1252 mixup in German",
+        "original": "\u0084Handwerk bringt dich überall hin\u0093: Von der YOU bis nach Monaco",
+        "fixed-encoding": "„Handwerk bringt dich überall hin“: Von der YOU bis nach Monaco",
+        "fixed": "\"Handwerk bringt dich überall hin\": Von der YOU bis nach Monaco",
+        "expect": "pass"
+    },
+    {
+        "label": "Latin-1 / Windows-1252 mixup of the replacement character",
+        "original": "Some comments may be republished on the website or in the newspaper ï¿½ email addresses will not be published.",
+        "fixed": "Some comments may be republished on the website or in the newspaper � email addresses will not be published.",
+        "expect": "pass"
+    },
+    {
+        "label": "CESU-8 / Windows-1252 emoji",
+        "original": "Hi guys í ½í¸\u008d",
+        "fixed": "Hi guys 😍",
+        "expect": "pass"
+    },
+    {
+        "label": "CESU-8 / Latin-1 emoji",
+        "original": "hihi RT username: â\u0098ºí ½í¸\u0098",
+        "fixed": "hihi RT username: ☺😘",
+        "expect": "pass"
+    },
+    {
+        "label": "Latin-1 / Windows-1252 mixup in Turkish",
+        "original": "Beta Haber: HÄ±rsÄ±zÄ± BÃ¼yÃ¼ Korkuttu",
+        "fixed": "Beta Haber: Hırsızı Büyü Korkuttu",
+        "expect": "pass"
+    },
+    {
+        "label": "Latin-1 / Windows-1252 mixup in İstanbul (issue #192)",
+        "original": "Ä°stanbul",
+        "fixed": "İstanbul",
+        "expect": "pass"
+    },
+    {
+        "label": "Latin-1 / Windows-1252 mixup in German (issue #188)",
+        "original": "RUF MICH ZURÃœCK",
+        "fixed": "RUF MICH ZURÜCK",
+        "expect": "pass"
+    },
+    {
+        "label": "Latin-1 / Windows-1252 mixup in Rīga (issue #192)",
+        "original": "RÄ«ga",
+        "fixed": "Rīga",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1251 mixed up twice in Russian",
+        "original": "Р С—РЎР‚Р С‘РЎРЏРЎвЂљР Р…Р С•РЎРѓРЎвЂљР С‘. РІСњВ¤",
+        "fixed": "приятности. ❤",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1252 mixed up twice in Malay",
+        "original": "Kayanya laptopku error deh, soalnya tiap mau ngetik deket-deket kamu font yg keluar selalu Times New Ã¢â‚¬Å“ RomanceÃ¢â‚¬Â\u009d.",
+        "fixed-encoding": "Kayanya laptopku error deh, soalnya tiap mau ngetik deket-deket kamu font yg keluar selalu Times New “ Romance”.",
+        "fixed": "Kayanya laptopku error deh, soalnya tiap mau ngetik deket-deket kamu font yg keluar selalu Times New \" Romance\".",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1252 mixed up twice in naming Iggy Pop",
+        "original": "Iggy Pop (nÃƒÂ© Jim Osterberg)",
+        "fixed": "Iggy Pop (né Jim Osterberg)",
+        "expect": "pass"
+    },
+    {
+        "label": "Left quote is UTF-8, right quote is Latin-1, both encoded in Windows-1252",
+        "original": "Direzione Pd, ok â\u0080\u009csenza modifiche\u0094 all'Italicum.",
+        "fixed-encoding": "Direzione Pd, ok “senza modifiche” all'Italicum.",
+        "fixed": "Direzione Pd, ok \"senza modifiche\" all'Italicum.",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / sloppy Windows-1252 mixed up twice in a triumphant emoticon",
+        "original": "selamat berpuasa sob (Ã\u00a0Â¸â€¡'ÃŒâ‚¬Ã¢Å’Â£'ÃŒÂ\u0081)Ã\u00a0Â¸â€¡",
+        "fixed": "selamat berpuasa sob (ง'̀⌣'́)ง",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1252 mixed up three times",
+        "original": "The Mona Lisa doesnÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢t have eyebrows.",
+        "fixed-encoding": "The Mona Lisa doesn’t have eyebrows.",
+        "fixed": "The Mona Lisa doesn't have eyebrows.",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Codepage 437 mixup in Russian",
+        "original": "#╨┐╤Ç╨░╨▓╨╕╨╗╤î╨╜╨╛╨╡╨┐╨╕╤é╨░╨╜╨╕╨╡",
+        "fixed": "#правильноепитание",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1252 mixup in French",
+        "original": "HÃ´tel de Police",
+        "fixed": "Hôtel de Police",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1250 mixup in French",
+        "original": "LiĂ¨ge Avenue de l'HĂ´pital",
+        "fixed": "Liège Avenue de l'Hôpital",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1252 mixup in Vietnamese",
+        "original": "Táº¡i sao giÃ¡ háº¡t sáº§u riÃªng láº¡i lÃªn giÃ¡?",
+        "fixed": "Tại sao giá hạt sầu riêng lại lên giá?",
+        "expect": "pass"
+    },
+    {
+        "label": "Science! Mid-word Greek letter gets fixed correctly",
+        "original": "Humanized HLA-DR4.RagKO.IL2RÎ³cKO.NOD (DRAG) mice sustain the complex vertebrate life cycle of Plasmodium falciparum malaria.",
+        "fixed": "Humanized HLA-DR4.RagKO.IL2RγcKO.NOD (DRAG) mice sustain the complex vertebrate life cycle of Plasmodium falciparum malaria.",
+        "expect": "pass"
+    },
+    {
+        "label": "For goodness' sake. We can come close to fixing this, but fail in the last step",
+        "original": "ItÃ?Â¢â?¬â?¢s classic. ItÃ?Â¢â?¬â?¢s epic. ItÃ?Â¢â?¬â?¢s ELIZABETH BENNET for goodnessÃ?Â¢â?¬â?¢ sake!",
+        "fixed": "It�¢��s classic. It�¢��s epic. It�¢��s ELIZABETH BENNET for goodness�¢�� sake!",
+        "expect": "pass"
+    },
+    {
+        "label": "lossy UTF-8 / Windows-1250 mixup in Spanish",
+        "original": "Europa, Asia, Ă�frica, Norte, AmĂ©rica Central y del Sur, Australia y OceanĂ­a",
+        "fixed": "Europa, Asia, �frica, Norte, América Central y del Sur, Australia y Oceanía",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / sloppy Windows-1250 mixup in English",
+        "original": "It was namedÂ â€žscarsÂ´ stonesâ€ś after the rock-climbers who got hurt while climbing on it.",
+        "fixed-encoding": "It was named\u00a0„scars´ stones“ after the rock-climbers who got hurt while climbing on it.",
+        "fixed": "It was named\u00a0\"scars´ stones\" after the rock-climbers who got hurt while climbing on it.",
+        "expect": "pass"
+    },
+    {
+        "label": "The same text as above, but as a UTF-8 / ISO-8859-2 mixup",
+        "original": "It was namedÂ\u00a0â\u0080\u009escarsÂ´ stonesâ\u0080\u009c after the rock-climbers who got hurt while climbing on it.",
+        "fixed-encoding": "It was named\u00a0„scars´ stones“ after the rock-climbers who got hurt while climbing on it.",
+        "fixed": "It was named\u00a0\"scars´ stones\" after the rock-climbers who got hurt while climbing on it.",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / ISO-8859-2 mixup in Czech",
+        "comment": "This says 'I've had enough of the third millennium', which is great because it involves software decisions made in the second",
+        "original": "MĂĄm dost tĹ\u0099etĂ\u00adho tisĂ\u00adciletĂ\u00ad",
+        "fixed": "Mám dost třetího tisíciletí",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1252 mixup in mixed French and Arabic",
+        "comment": "A difficult test case that can depend on the order that steps are applied",
+        "original": "Ã€ tous mes frÃ¨res et soeurs dans la syriennetÃ© comme dans l’humanitÃ©, sans discrimination aucune, je vous souhaite bonne fÃªte Ø¹ÙŠØ¯ Ø³Ø¹ÙŠØ¯.Que la paix, la libertÃ©, l’Ã©galitÃ©, la fraternitÃ© et la dignitÃ© soient avec vous.Pardonnez ce ton un peu ecclÃ©siastique.",
+        "fixed-encoding": "À tous mes frères et soeurs dans la syrienneté comme dans l’humanité, sans discrimination aucune, je vous souhaite bonne fête عيد سعيد.Que la paix, la liberté, l’égalité, la fraternité et la dignité soient avec vous.Pardonnez ce ton un peu ecclésiastique.",
+        "fixed": "À tous mes frères et soeurs dans la syrienneté comme dans l'humanité, sans discrimination aucune, je vous souhaite bonne fête عيد سعيد.Que la paix, la liberté, l'égalité, la fraternité et la dignité soient avec vous.Pardonnez ce ton un peu ecclésiastique.",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / sloppy Windows-1250 mixup in Romanian",
+        "original": "vedere Ă®nceĹŁoĹźatÄ\u0083",
+        "fixed": "vedere înceţoşată",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1250 mixup in Slovak",
+        "original": "NapĂ\u00adĹˇte nĂˇm !",
+        "fixed": "Napíšte nám !",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1252 mixup in Spanish",
+        "original": "DOS AÃ‘OS",
+        "fixed": "DOS AÑOS",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1252 followed by UTF-8 / Windows-1251",
+        "original": "a bigger-than-expected Г‚ВЈ5.8bn rights issue to satisfy the new banking regulator",
+        "fixed": "a bigger-than-expected £5.8bn rights issue to satisfy the new banking regulator",
+        "expect": "pass"
+    },
+    {
+        "label": "fancy Unicode crossing-out, but mojibaked",
+        "original": "hotel $49 $Ì¶6Ì¶3Ì¶ updated 2018",
+        "fixed": "hotel $49 $̶6̶3̶ updated 2018",
+        "expect": "pass"
+    },
+    {
+        "label": "A face with UTF-8 / sloppy Windows-1252 mixed up twice",
+        "original": "Ã¢â€\u009dâ€™(Ã¢Å’Â£Ã‹â€ºÃ¢Å’Â£)Ã¢â€\u009dÅ½",
+        "fixed": "┒(⌣˛⌣)┎",
+        "expect": "pass"
+    },
+    {
+        "label": "We can mostly decode the face above when we lose the character U+009D",
+        "original": "Ã¢â€�â€™(Ã¢Å’Â£Ã‹â€ºÃ¢Å’Â£)Ã¢â€�Å½",
+        "fixed": "�(⌣˛⌣)�",
+        "expect": "pass"
+    },
+    {
+        "label": "Lossy decoding can have plain ASCII question marks, as well",
+        "original": "The ICR has been upgraded to â€œbb+â€? from â€œbbâ€?",
+        "fixed-encoding": "The ICR has been upgraded to “bb+� from “bb�",
+        "fixed": "The ICR has been upgraded to \"bb+� from \"bb�",
+        "expect": "pass"
+    },
+    {
+        "label": "CESU-8 / Latin-1 mixup over several emoji",
+        "comment": "You tried",
+        "original": "I just figured out how to tweet emojis! â\u009a½í\u00a0½í¸\u0080í\u00a0½í¸\u0081í\u00a0½í¸\u0082í\u00a0½í¸\u0086í\u00a0½í¸\u008eí\u00a0½í¸\u008eí\u00a0½í¸\u008eí\u00a0½í¸\u008e",
+        "fixed": "I just figured out how to tweet emojis! ⚽😀😁😂😆😎😎😎😎",
+        "expect": "pass"
+    },
+    {
+        "label": "An absolutely hopeless garble",
+        "comment": "If we try too hard to decode this, we'll recursively apply `decode_inconsistent_utf8` until the characters turn into random Han and katakana characters.",
+        "original": "ã†â€™ãƒâ€ ã¢â‚¬â„¢ãƒæ’ã‚â¢ãƒâ¢ã¢â‚¬å¡ã‚â¬ãƒâ€šã‚â",
+        "fixed-encoding": "ã†â€™ãƒâ€ ã¢â‚¬â„¢ãƒæ’ã‚â¢ãƒâ¢ã¢â‚¬å¡ã‚â¬ãƒâ€šã‚â",
+        "fixed": "ã†â€™ãƒâ€ ã¢â'¬â\"¢ãƒæ'ã'â¢ãƒâ¢ã¢â'¬å¡ã'â¬ãƒâ€šã'â",
+        "expect": "pass"
+    },
+    {
+        "label": "Inconsistent UTF-8 / Latin-1 mojibake",
+        "original": "Ecuadorâ\u0080\u0099s â\u0080\u0098purely political decision on Assangeâ\u0080\u0099 is likely result of â\u0080\u0098US pressureâ\u0080\u0099\u0085",
+        "fixed-encoding": "Ecuador’s ‘purely political decision on Assange’ is likely result of ‘US pressure’…",
+        "fixed": "Ecuador's 'purely political decision on Assange' is likely result of 'US pressure'…",
+        "expect": "pass"
+    },
+    {
+        "label": "Inconsistent UTF-8 / Latin-1 mojibake with an ellipsis from the Windows-1252 character set",
+        "original": "Ecuadorâ\u0080\u0099s â\u0080\u0098purely political decision on Assangeâ\u0080\u0099 is likely result of â\u0080\u0098US pressureâ\u0080\u0099…",
+        "fixed-encoding": "Ecuador’s ‘purely political decision on Assange’ is likely result of ‘US pressure’…",
+        "fixed": "Ecuador's 'purely political decision on Assange' is likely result of 'US pressure'…",
+        "expect": "pass"
+    },
+    {
+        "label": "Inconsistent mojibake in Portuguese",
+        "original": "Campeonatos > III DivisÃ£o - SÃ©rie F > Jornadas Classificação",
+        "fixed": "Campeonatos > III Divisão - Série F > Jornadas Classificação",
+        "expect": "pass"
+    },
+    {
+        "label": "Handle Afrikaans 'n character",
+        "original": "ŉ Chloroplas is ŉ organel wat in fotosinterende plante voorkom.",
+        "fixed-encoding": "ŉ Chloroplas is ŉ organel wat in fotosinterende plante voorkom.",
+        "fixed": "'n Chloroplas is 'n organel wat in fotosinterende plante voorkom.",
+        "expect": "pass"
+    },
+    {
+        "label": "Handle Croatian single-codepoint digraphs",
+        "original": "izum „bootstrap load“ koji je korišteǌem polisilicijskog sloja proizveo dovoǉno dobre kondenzatore na čipu",
+        "fixed-encoding": "izum „bootstrap load“ koji je korišteǌem polisilicijskog sloja proizveo dovoǉno dobre kondenzatore na čipu",
+        "fixed": "izum \"bootstrap load\" koji je korištenjem polisilicijskog sloja proizveo dovoljno dobre kondenzatore na čipu",
+        "expect": "pass"
+    },
+    {
+        "label": "A with an acute accent, in isolation",
+        "original": "NicolÃ¡s",
+        "fixed": "Nicolás",
+        "expect": "pass"
+    },
+    {
+        "label": "sharp S, in isolation, via MacRoman encoding",
+        "comment": "regression reported in issue #186",
+        "original": "wei√ü",
+        "fixed": "weiß",
+        "expect": "pass"
+    },
+    {
+        "label": "French example containing non-breaking spaces",
+        "original": "ART TRIP Ã\u00a0 l'office de tourisme",
+        "fixed": "ART TRIP à l'office de tourisme",
+        "expect": "pass"
+    },
+    {
+        "label": "English example in UTF-8 / Windows-1251 with a ligature",
+        "original": "This is signiп¬Ѓcantly lower than the respective share",
+        "fixed-encoding": "This is signiﬁcantly lower than the respective share",
+        "fixed": "This is significantly lower than the respective share",
+        "expect": "pass"
+    },
+    {
+        "label": "'à' remains its own word, even if spaces after it get coalesced into one",
+        "original": "Ã perturber la rÃ©flexion des thÃ©ologiens jusqu'Ã nos jours",
+        "fixed": "à perturber la réflexion des théologiens jusqu'à nos jours",
+        "expect": "pass"
+    },
+    {
+        "label": "Fix 'à' in inconsistent mojibake",
+        "original": "Le barÃ¨me forfaitaire permet l’Ã©valuation des frais de dÃ©placement relatifs Ã l’utilisation",
+        "fixed-encoding": "Le barème forfaitaire permet l’évaluation des frais de déplacement relatifs à l’utilisation",
+        "fixed": "Le barème forfaitaire permet l'évaluation des frais de déplacement relatifs à l'utilisation",
+        "expect": "pass"
+    },
+    {
+        "label": "The Portuguese word 'às' does not become 'à s' due to the French fix",
+        "original": "com especial atenÃ§Ã£o Ã s crianÃ§as",
+        "fixed": "com especial atenção às crianças",
+        "expect": "pass"
+    },
+    {
+        "label": "This is why we require a space after the 's' in 'às'",
+        "original": "TroisiÃ¨me Ã©dition pour ce festival qui persiste et signe Ã s'Ã©loigner des grands axes pour prendre les contre-allÃ©es en 16 concerts dans 7 villes de 2 pays voisins.",
+        "fixed": "Troisième édition pour ce festival qui persiste et signe à s'éloigner des grands axes pour prendre les contre-allées en 16 concerts dans 7 villes de 2 pays voisins.",
+        "expect": "pass"
+    },
+    {
+        "label": "We can fix 'à' in windows-1251 sometimes as well",
+        "original": "La rГ©gion de Dnepropetrovsk se trouve Г lвЂ™ouest de lвЂ™Ukraine",
+        "fixed-encoding": "La région de Dnepropetrovsk se trouve à l’ouest de l’Ukraine",
+        "fixed": "La région de Dnepropetrovsk se trouve à l'ouest de l'Ukraine",
+        "expect": "pass"
+    },
+    {
+        "label": "'Ã quele' is the Portuguese word 'àquele', not 'à quele'",
+        "original": "eliminado o antÃ­geno e mantidos os nÃ­veis de anticorpos, surgem as condiÃ§Ãµes necessÃ¡rias ao estabelecimento do granuloma, semelhante Ã quele observado nas lesÃµes por imunocomplexo em excesso de anticorpos",
+        "fixed": "eliminado o antígeno e mantidos os níveis de anticorpos, surgem as condições necessárias ao estabelecimento do granuloma, semelhante àquele observado nas lesões por imunocomplexo em excesso de anticorpos",
+        "expect": "pass"
+    },
+    {
+        "label": "A complex, lossy pile-up of mojibake in Portuguese",
+        "original": "â € ðŸ“�Â Regulamento: â € âš ï¸� As pessoas que marcarem nos comentÃ¡rios perfis empresariais e/ou de marcas, personalidades ou fake serÃ£o desclassificadas. âš ï¸� Podem participar pessoas residentes em Petrolina/PE ou Juazeiro/BA, desde que se comprometam a retirar o prÃªmio em nosso endereÃ§o. FuncionÃ¡rios estÃ£o vetados. âš ï¸� SerÃ£o vÃ¡lidos os comentÃ¡rios postados atÃ© 16h, do dia 31/03/2018. E o resultado serÃ¡ divulgado atÃ© Ã s 19h do mesmo dia em uma nova publicaÃ§Ã£o em nosso instagram. â € Boa sorte!!!Â ðŸ˜€ðŸ�°",
+        "fixed": "⠀ �\u00a0Regulamento: ⠀ ⚠� As pessoas que marcarem nos comentários perfis empresariais e/ou de marcas, personalidades ou fake serão desclassificadas. ⚠� Podem participar pessoas residentes em Petrolina/PE ou Juazeiro/BA, desde que se comprometam a retirar o prêmio em nosso endereço. Funcionários estão vetados. ⚠� Serão válidos os comentários postados até 16h, do dia 31/03/2018. E o resultado será divulgado até às 19h do mesmo dia em uma nova publicação em nosso instagram. ⠀ Boa sorte!!!\u00a0😀�",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1252 mixup in Gaelic involving non-breaking spaces",
+        "original": "CÃ\u00a0nan nan GÃ\u00a0idheal",
+        "fixed": "Cànan nan Gàidheal",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1251 mixup in tweet spam",
+        "original": "Blog Traffic Tip 2 вЂ“ Broadcast Email Your Blog",
+        "fixed": "Blog Traffic Tip 2 – Broadcast Email Your Blog",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / Windows-1251 mixup",
+        "original": "S&P Confirms UkrsotsbankвЂ™s вЂњB-вЂњ Rating",
+        "fixed-encoding": "S&P Confirms Ukrsotsbank’s “B-“ Rating",
+        "fixed": "S&P Confirms Ukrsotsbank's \"B-\" Rating",
+        "expect": "pass"
+    },
+    {
+        "label": "Dutch example with ë",
+        "comment": "from issue reported by MicroJackson",
+        "original": "ongeÃ«venaard",
+        "fixed-encoding": "ongeëvenaard",
+        "fixed": "ongeëvenaard",
+        "expect": "pass"
+    },
+    {
+        "label": "HTML entity on top of UTF-8 / Latin-1",
+        "original": "10Î&frac14;s",
+        "fixed-encoding": "10Î&frac14;s",
+        "fixed": "10μs",
+        "expect": "pass"
+    },
+    {
+        "label": "Three layers of UTF-8 / MacRoman mixup in French",
+        "comment": "You're welcome",
+        "original": "Merci de t‚Äö√†√∂¬¨¬©l‚Äö√†√∂¬¨¬©charger le plug-in Flash Player 8",
+        "fixed": "Merci de télécharger le plug-in Flash Player 8",
+        "expect": "pass"
+    },
+    {
+        "label": "UTF-8 / MacRoman mixup in French",
+        "original": "Merci de bien vouloir activiter le Javascript dans votre navigateur web afin d'en profiter‚Ä¶",
+        "fixed": "Merci de bien vouloir activiter le Javascript dans votre navigateur web afin d'en profiter…",
+        "expect": "pass"
+    },
+    {
+        "label": "Italian UTF-8 / MacRoman example with ò",
+        "original": "Le Vigne di Zam√≤",
+        "fixed": "Le Vigne di Zamò",
+        "expect": "pass"
+    },
+    {
+        "label": "Punctuation pile-up should actually be musical notes",
+        "original": "Engkau masih yg terindah, indah di dalam hatikuâ™«~",
+        "fixed": "Engkau masih yg terindah, indah di dalam hatiku♫~",
+        "expect": "pass"
+    },
+    {
+        "label": "Latvian UTF-8 / Windows-1257 mojibake",
+        "original": "Å veices baÅ†Ä·ieri gaida konkrÄ“tus investÄ«ciju projektus",
+        "fixed": "Šveices baņķieri gaida konkrētus investīciju projektus",
+        "expect": "pass"
+    },
+    {
+        "label": "Latvian UTF-8 / MacRoman mojibake",
+        "original": "SaeimƒÅ ievƒìlƒìtƒÅs partijas \"Progresƒ´vie\" lƒ´dzvadƒ´tƒÅja Anto≈Üina ≈Öena≈°eva atbild uz ≈æurnƒÅlistu jautƒÅjumiem pƒìc partijas tik≈°anƒÅs ar Valsts prezidentu Rƒ´gas pilƒ´,",
+        "fixed": "Saeimā ievēlētās partijas \"Progresīvie\" līdzvadītāja Antoņina Ņenaševa atbild uz žurnālistu jautājumiem pēc partijas tikšanās ar Valsts prezidentu Rīgas pilī,",
+        "expect": "pass"
+    },
+    {
+        "label": "Lithuanian UTF-8 / Windows-1257 mojibake",
+        "original": "Å iaip ÄÆdomu, kaip ÄÆsivaizduoji. VisÅ³ pirma tam reikia laiko.",
+        "fixed": "Šiaip įdomu, kaip įsivaizduoji. Visų pirma tam reikia laiko.",
+        "expect": "pass"
+    },
+    {
+        "label": "Lithuanian UTF-8 / Windows-1250 mojibake",
+        "original": "Lietuva pagrÄŻstai gali paklausti: Ĺ˝inoma, kad ne.",
+        "fixed": "Lietuva pagrįstai gali paklausti: Žinoma, kad ne.",
+        "expect": "pass"
+    },
+    {
+        "label": "Hebrew UTF-8 / Windows-1252 mojibake",
+        "comment": "reported by SuperIRabbit as issue #158",
+        "original": "×‘×”×•×“×¢×”",
+        "fixed": "בהודעה",
+        "expect": "pass"
+    },
+    {
+        "label": "Wide comma in UTF-8 / Windows-1252",
+        "original": "Ningboï¼ŒChina",
+        "fixed-encoding": "Ningbo，China",
+        "fixed": "Ningbo,China",
+        "expect": "pass"
+    }
+]

--- a/python/tests/test-cases/known-failures.json
+++ b/python/tests/test-cases/known-failures.json
@@ -1,0 +1,70 @@
+[
+    {
+        "label": "Misleading mix-up in Spanish",
+        "comment": "The original text has mojibake, but the sequence 'á \u0093' can decode as U+1813 MONGOLIAN DIGIT THREE, when the whole string should really just decode as a Latin-1/Windows-1252 mixup",
+        "original": "tiene demora y está \u0093próximo a resolverse\u0094",
+        "fixed": "tiene demora y está \"próximo a resolverse\"",
+        "expect": "fail"
+    },
+    {
+        "label": "Two levels of inconsistent mojibake",
+        "comment": "The en-dash was mojibaked in UTF-8 / Windows-1252 as three characters, two of which were mojibaked again as Windows-1252 / Latin-1, and the third of which was mojibaked as UTF-8 / Latin-1. Unfortunately, if we fix this, we leave ourselves room to greedily 'decode' random Han characters in complex Latin-alphabet mojibake",
+        "original": "Arsenal v Wolfsburg: pre-season friendly â\u0080â\u0080\u009c live!",
+        "fixed": "Arsenal v Wolfsburg: pre-season friendly – live!",
+        "expect": "fail"
+    },
+    {
+        "label": "A-with-grave in Vietnamese",
+        "comment": "Currently adds extra spaces that shouldn't be there",
+        "original": "Xem clip hĂ i, phim hĂ i má»›i hay nháşĄt",
+        "fixed": "Xem clip hài, phim hài mới hay nhất",
+        "expect": "fail"
+    },
+    {
+        "label": "Latin-1 / MacRoman mixup in Spanish",
+        "comment": "Requires something like encoding detection",
+        "original": "Deja dos heridos hundimiento de barco tur\u0092stico en Acapulco.",
+        "fixed": "Deja dos heridos hundimiento de barco turístico en Acapulco.",
+        "expect": "fail"
+    },
+    {
+        "label": "subtle UTF-8 / codepage 437 mixup in Spanish",
+        "original": "┬┐que diferencia hay?",
+        "fixed": "¿que diferencia hay?",
+        "expect": "fail"
+    },
+    {
+        "label": "Latin-1 / MacRoman mixup in Spanish, 2 characters",
+        "comment": "Requires something like encoding detection",
+        "original": "Habitantes de Coatl\u0087n conf\u0092an en proyecto de edil electo independiente",
+        "fixed": "Habitantes de Coatlán confían en proyecto de edil electo independiente",
+        "expect": "fail"
+    },
+    {
+        "label": "An example with 'à' in windows-1251 where we need our heuristic to be bolder",
+        "original": "faites attention Г bien vous renseigner avant sur le mГ©dicament",
+        "fixed": "faites attention à bien vous renseigner avant sur le médicament",
+        "expect": "fail"
+    },
+    {
+        "label": "Italian UTF-8 / MacRoman mojibake that looks like math",
+        "comment": "False negative: 'pi√π' is a bit too reasonable to fix",
+        "original": "Sarai ricontattato dal nostro Esperto al pi√π presto.",
+        "fixed": "Sarai ricontattato dal nostro Esperto al più presto.",
+        "expect": "fail"
+    },
+    {
+        "label": "Synthetic: Incomplete UTF-8 / Windows-1252 mixup in Arabic",
+        "comment": "I find text like this in OSCAR a fair amount, but couldn't isolate a good example that tested digits. The intended text means 'more than 100 countries'.",
+        "original": "أكثر Ù…Ù† Ù Ù Ù¡ Ø¨Ù„Ø¯",
+        "fixed": "أكثر من ٠٠١ بلد",
+        "expect": "fail"
+    },
+    {
+        "label": "Synthetic, false positive: the title of a manga, in weird capitalized romaji, with a non-breaking space",
+        "comment": "Testing tells me I should worry about cases like this, though I haven't seen a real example. Searching for similar real text yields a lot of examples that actually come out fine.",
+        "original": "MISUTÂ\u00a0AJIKKO",
+        "fixed": "MISUTÂ\u00a0AJIKKO",
+        "expect": "fail"
+    }
+]

--- a/python/tests/test-cases/language-names.json
+++ b/python/tests/test-cases/language-names.json
@@ -1,0 +1,127 @@
+[
+    {
+        "label": "Messy language names: Czech",
+        "comment": "This and several following examples came from the same language selector",
+        "original": "ÄŒeÅ¡tina",
+        "fixed": "Čeština",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Gaelic",
+        "comment": "note that if U+A0 is replaced by a space, it comes out slightly incorrectly as 'Gà idhlig'",
+        "original": "GÃ\u00a0idhlig",
+        "fixed": "Gàidhlig",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Lithuanian",
+        "original": "LietuviÅ³",
+        "fixed": "Lietuvių",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Slovak",
+        "original": "SlovenÄ�ina",
+        "fixed": "Sloven�ina",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Vietnamese",
+        "original": "Tiáº¿ng Viá»‡t",
+        "fixed": "Tiếng Việt",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Greek",
+        "original": "Î•Î»Î»Î·Î½Î¹ÎºÎ¬",
+        "fixed": "Ελληνικά",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Bulgarian",
+        "original": "Ð±ÑŠÐ»Ð³Ð°Ñ€Ñ�ÐºÐ¸ ÐµÐ·Ð¸Ðº",
+        "fixed": "българ�ки език",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Russian",
+        "original": "Ð ÑƒÑ�Ñ�ÐºÐ¸Ð¹",
+        "fixed": "Ру��кий",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Serbian [Cyrillic]",
+        "original": "CÑ€Ð¿Ñ�ÐºÐ¸ [Ñ›Ð¸Ñ€Ð¸Ð»Ð¸Ñ†Ð¾Ð¼]",
+        "fixed": "Cрп�ки [ћирилицом]",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Hebrew",
+        "original": "×¢×‘×¨×™×ª",
+        "fixed": "עברית",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Russian",
+        "original": "Ð ÑƒÑ�Ñ�ÐºÐ¸Ð¹",
+        "fixed": "Ру��кий",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Hindi",
+        "comment": "My terminal has difficulty rendering the mostly-fixed text",
+        "original": "à¤¹à¤¿à¤¨à¥�à¤¦à¥€",
+        "fixed": "\u0939\u093f\u0928\ufffd\u0926\u0940",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Tamil",
+        "comment": "My terminal has difficulty rendering the mostly-fixed text",
+        "original": "à®¤à®®à®¿à®´à¯�",
+        "fixed": "\u0ba4\u0bae\u0bbf\u0bb4\ufffd",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Thai",
+        "original": "à¸ à¸²à¸©à¸²à¹„à¸—à¸¢",
+        "fixed": "ภาษาไทย",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Simplified Chinese",
+        "original": "ç®€ä½“ä¸\u00adæ–‡",
+        "fixed": "简体中文",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Traditional Chinese",
+        "original": "æ\u00ad£é«”ä¸\u00adæ–‡",
+        "fixed": "正體中文",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Japanese",
+        "original": "æ—¥æœ¬èªž",
+        "fixed": "日本語",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language names: Korean",
+        "original": "í•œêµ\u00adì–´",
+        "fixed": "한국어",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language name in cp437: Czech",
+        "comment": "A synthetic example, I suppose, but goes with the other language name tests",
+        "original": "─îe┼ítina",
+        "fixed": "Čeština",
+        "expect": "pass"
+    },
+    {
+        "label": "Messy language name in cp437: Vietnamese",
+        "original": "Tiß║┐ng Viß╗çt",
+        "fixed": "Tiếng Việt",
+        "expect": "pass"
+    }
+]

--- a/python/tests/test-cases/negative.json
+++ b/python/tests/test-cases/negative.json
@@ -1,0 +1,216 @@
+[
+    {
+        "label": "Negative: Using diaereses as quotation marks in Greek",
+        "comment": "Examples in this file might be detected as mojibake-like, but should not be changed",
+        "original": "Η ¨ανατροφή¨ δυστυχώς από τους προπονητές",
+        "fixed": "Η ¨ανατροφή¨ δυστυχώς από τους προπονητές",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: Don't fix a multiplication symbol in quotes",
+        "original": "higher values (“+” and “×” curves) in the superficial region",
+        "fixed-encoding": "higher values (“+” and “×” curves) in the superficial region",
+        "fixed": "higher values (\"+\" and \"×\" curves) in the superficial region",
+        "expect": "pass"
+    },
+    {
+        "label": "Sort of negative: this inconsistent mojibake could be Latin-1 or MacRoman, and it was meant to be Latin-1, but it's safest to not decode it as either",
+        "comment": "issue #202",
+        "original": "Bremer/Mccoy – DrÃ¥ber",
+        "fixed": "Bremer/Mccoy – DrÃ¥ber",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: 'è' preceded by a non-breaking space is not a small capital Y",
+        "original": "Con il corpo e lo spirito ammaccato,\u00a0è come se nel cuore avessi un vetro conficcato.",
+        "fixed": "Con il corpo e lo spirito ammaccato,\u00a0è come se nel cuore avessi un vetro conficcato.",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: multiplication sign and ellipsis",
+        "comment": "Should not turn into a dot below",
+        "original": "4288×…",
+        "fixed": "4288×…",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: accents are sometimes used as quotes",
+        "comment": "Under a previous heuristic, this tested the CESU-8 decoder, which would try to decode it and fail when it hit the end of the string",
+        "original": "``toda produzida pronta pra assa aí´´",
+        "fixed": "``toda produzida pronta pra assa aí´´",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: 'Õ' followed by an ellipsis",
+        "comment": "Should not turn into the Armenian letter Յ",
+        "original": "HUHLL Õ…",
+        "fixed": "HUHLL Õ…",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: 'Ê' followed by an ellipsis",
+        "comment": "Should not turn into a squat reversed esh",
+        "original": "RETWEET SE VOCÊ…",
+        "fixed": "RETWEET SE VOCÊ…",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: 'É' followed by an ellipsis",
+        "comment": "Should not turn into 'MARQUɅ'",
+        "original": "PARCE QUE SUR LEURS PLAQUES IL Y MARQUÉ…",
+        "fixed": "PARCE QUE SUR LEURS PLAQUES IL Y MARQUÉ…",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: 'Ó' followed by an ellipsis",
+        "comment": "Should not turn into 'SӅ'",
+        "original": "TEM QUE SEGUIR, SDV SÓ…",
+        "fixed": "TEM QUE SEGUIR, SDV SÓ…",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: 'É' followed by a curly apostrophe",
+        "comment": "Should not turn into 'ZZAJɒs'",
+        "original": "Join ZZAJÉ’s Official Fan List and receive news, events, and more!",
+        "fixed-encoding": "Join ZZAJÉ’s Official Fan List and receive news, events, and more!",
+        "fixed": "Join ZZAJÉ's Official Fan List and receive news, events, and more!",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: 'é' preceded by curly apostrophe",
+        "comment": "Should not turn into 'LՎpisode'",
+        "original": "L’épisode 8 est trop fou ouahh",
+        "fixed-encoding": "L’épisode 8 est trop fou ouahh",
+        "fixed": "L'épisode 8 est trop fou ouahh",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: three raised eyebrows or something?",
+        "comment": "Should not turn into private use character U+F659",
+        "original": "Ôôô VIDA MINHA",
+        "fixed": "Ôôô VIDA MINHA",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: copyright sign preceded by non-breaking space",
+        "comment": "Should not turn into 'ʩ'",
+        "original": "[x]\u00a0©",
+        "fixed": "[x]\u00a0©",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: en dash and infinity sign",
+        "comment": "Should not turn into '2012Ѱ'",
+        "original": "2012—∞",
+        "fixed": "2012—∞",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: This Е is a Ukrainian letter, but nothing else is wrong",
+        "original": "SENSЕ - Oleg Tsedryk",
+        "fixed": "SENSЕ - Oleg Tsedryk",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: angry face",
+        "comment": "The face should not turn into '`«'",
+        "original": "OK??:(   `¬´    ):",
+        "fixed": "OK??:(   `¬´    ):",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative, synthetic: face with glasses and a raised eyebrow",
+        "original": "( o¬ô )",
+        "fixed": "( o¬ô )",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: triangle and degree sign",
+        "comment": "I'm not really sure what it *is* supposed to be, but it's not 'ơ'",
+        "original": "∆°",
+        "fixed": "∆°",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: Portuguese with inverted question mark",
+        "comment": "Former false positive - it should not turn into 'QUEM ɿ'",
+        "original": "ESSE CARA AI QUEM É¿",
+        "fixed": "ESSE CARA AI QUEM É¿",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: Portuguese with acute accents as quotation marks",
+        "comment": "Former false positive - the end should not turn into a superscript H",
+        "original": "``hogwarts nao existe, voce nao vai pegar o trem pra lá´´",
+        "fixed": "``hogwarts nao existe, voce nao vai pegar o trem pra lá´´",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: Finnish Ä followed by a non-breaking space",
+        "comment": "Former false positive - should not become a G with a dot",
+        "original": "SELKÄ\u00a0EDELLÄ\u00a0MAAHAN via @YouTube",
+        "fixed": "SELKÄ\u00a0EDELLÄ\u00a0MAAHAN via @YouTube",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: multiplying by currency",
+        "comment": "Former false positive - should not become the Hebrew letter 'final pe'",
+        "original": "Offering 5×£35 pin ups",
+        "fixed": "Offering 5×£35 pin ups",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: registered chocolate brand name",
+        "comment": "Former false positive - should not become the IPA letter 'lezh'",
+        "original": "NESTLÉ® requiere contratar personal para diferentes areas a nivel nacional e internacional",
+        "fixed": "NESTLÉ® requiere contratar personal para diferentes areas a nivel nacional e internacional",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: it looks like Windows-1257 mojibake but someone writes their name this way",
+        "comment": "Should not become a cedilla",
+        "original": "Connect with Āø on Facebook",
+        "fixed": "Connect with Āø on Facebook",
+        "expect": "pass"
+    },
+    {
+        "label": "Mostly negative: we only need to fix C1 control characters",
+        "comment": "We should not decode 'é\u0085 ' as '酠'",
+        "original": "C'est vrai que nous n'en avons pas encore beaucoup parlé\u0085 Tu sais, ça fait de nombreuses années",
+        "fixed": "C'est vrai que nous n'en avons pas encore beaucoup parlé… Tu sais, ça fait de nombreuses années",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: We don't fix Ã in all contexts",
+        "original": "C O N C L U S Ã O",
+        "fixed": "C O N C L U S Ã O",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: Two concatenated strings",
+        "comment": "Should not turn into 'fratarak᧠141'",
+        "original": "Oborzos, per. Vahbarz, frataraká§ 141",
+        "fixed": "Oborzos, per. Vahbarz, frataraká§ 141",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: Indonesian leetspeak",
+        "original": "MÄ£ÄM ÌÑÌ Q £ÄGÌ GÄLÄW ÑÍCH SÖÄ£ ÑÝÄ $ÚÄMÌ Q £ÄGÌ GÄK ÉÑÄK BÄDÄÑ....?????????,                     ......JÄDÍ...",
+        "fixed": "MÄ£ÄM ÌÑÌ Q £ÄGÌ GÄLÄW ÑÍCH SÖÄ£ ÑÝÄ $ÚÄMÌ Q £ÄGÌ GÄK ÉÑÄK BÄDÄÑ....?????????,                     ......JÄDÍ...",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: math in Unicode",
+        "comment": "This isn't mojibake, it's an actual equation",
+        "original": "(-1/2)! = √π",
+        "fixed": "(-1/2)! = √π",
+        "expect": "pass"
+    },
+    {
+        "label": "Negative: Leet line-art",
+        "comment": "The heuristic before v6 loved to 'fix' this and decode it as 'ôaſaſaſaſa'",
+        "original": "├┤a┼┐a┼┐a┼┐a┼┐a",
+        "fixed": "├┤a┼┐a┼┐a┼┐a┼┐a",
+        "expect": "pass"
+    }
+]

--- a/python/tests/test-cases/synthetic.json
+++ b/python/tests/test-cases/synthetic.json
@@ -1,0 +1,208 @@
+[
+    {
+        "label": "Synthetic: we can recognize Ã in some cases when it's the only mojibake",
+        "comment": "Examples in this file were made up to test something, instead of found in the wild",
+        "original": "voilÃ  le travail",
+        "fixed": "voilà le travail",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: we can recognize Ã at the end of a word when it absorbs a following space",
+        "original": "voilÃ le travail",
+        "fixed": "voilà le travail",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: Hebrew UTF-8 / Windows-1250 mojibake",
+        "original": "×‘×”×•×“×˘×”",
+        "fixed": "בהודעה",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: Hebrew UTF-8 / MacRoman mojibake",
+        "original": "◊ë◊î◊ï◊ì◊¢◊î",
+        "fixed": "בהודעה",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: Hebrew UTF-8 / Latin-1 mojibake",
+        "comment": "This example uses low-numbered codepoints to spell 'ABBA' in Hebrew, so that it falls into the range where Latin-1 is different from Windows-1252. As a bonus, this example looks right even if your RTL text rendering isn't working.",
+        "original": "×\u0090×\u0091×\u0091×\u0090",
+        "fixed": "אבבא",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: Arabic UTF-8 / Windows-1252 mojibake",
+        "original": "Ø±Ø³Ø§Ù„Ø©",
+        "fixed": "رسالة",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: Arabic UTF-8 / Windows-1250 mojibake",
+        "original": "Ř±ŘłŘ§Ů„Ř©",
+        "fixed": "رسالة",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: Arabic UTF-8 / MacRoman mojibake",
+        "original": "ÿ±ÿ≥ÿßŸÑÿ©",
+        "fixed": "رسالة",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: Brontë's name does not end with a Korean syllable",
+        "comment": "The original example of why ftfy needs heuristics",
+        "original": "I'm not such a fan of Charlotte Brontë…”",
+        "fixed-encoding": "I'm not such a fan of Charlotte Brontë…”",
+        "fixed": "I'm not such a fan of Charlotte Brontë…\"",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: hypothetical Swedish product name",
+        "comment": "This used to be a constructed example of a false positive, until you added another symbol",
+        "original": "AHÅ™, the new sofa from IKEA",
+        "fixed": "AHÅ™, the new sofa from IKEA",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: Ukrainian capital letters",
+        "comment": "We need to fix Windows-1251 conservatively, or else this decodes as '²ʲ'",
+        "original": "ВІКІ is Ukrainian for WIKI",
+        "fixed": "ВІКІ is Ukrainian for WIKI",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: don't leak our internal use of byte 0x1A",
+        "comment": "We use byte 0x1A internally as an encoding of U+FFFD, but literal occurrences of U+1A are just ASCII control characters",
+        "original": "These control characters \u001a are apparently intentional \u0081",
+        "fixed-encoding": "These control characters \u001a are apparently intentional \u0081",
+        "fixed": "These control characters  are apparently intentional \u0081",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: U+1A on its own",
+        "comment": "We use byte 0x1A internally as an encoding of U+FFFD, but literal occurrences of U+1A are just ASCII control characters",
+        "original": "Here's a control character: \u001a",
+        "fixed-encoding": "Here's a control character: \u001a",
+        "fixed": "Here's a control character: ",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: A-with-circle as an Angstrom sign",
+        "comment": "Should not turn into '10 ŗ'",
+        "original": "a radius of 10 Å—",
+        "fixed": "a radius of 10 Å—",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: Spanish with exclamation points on the wrong sides",
+        "original": "!YO SÉ¡",
+        "fixed": "!YO SÉ¡",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: fix text with backslashes in it",
+        "comment": "Tests for a regression on a long-ago bug",
+        "original": "<40\\% vs \u00e2\u0089\u00a540\\%",
+        "fixed": "<40\\% vs ≥40\\%",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: curly quotes with mismatched encoding glitches in Latin-1",
+        "original": "\u00e2\u0080\u009cmismatched quotes\u0085\u0094",
+        "fixed-encoding": "“mismatched quotes…”",
+        "fixed": "\"mismatched quotes…\"",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: curly quotes with mismatched encoding glitches in Windows-1252",
+        "original": "â€œmismatched quotesâ€¦”",
+        "fixed-encoding": "“mismatched quotes…”",
+        "fixed": "\"mismatched quotes…\"",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: lossy decoding in sloppy-windows-1252",
+        "original": "â€œlossy decodingâ€�",
+        "fixed-encoding": "“lossy decoding�",
+        "fixed": "\"lossy decoding�",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: French word for August in windows-1252",
+        "original": "aoÃ»t",
+        "fixed-encoding": "août",
+        "fixed": "août",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: French word for hotel in all-caps windows-1252",
+        "original": "HÃ”TEL",
+        "fixed-encoding": "HÔTEL",
+        "fixed": "HÔTEL",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: Scottish Gaelic word for 'subject' in all-caps windows-1252",
+        "original": "CÃ™IS",
+        "fixed-encoding": "CÙIS",
+        "fixed": "CÙIS",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: Romanian word before a non-breaking space",
+        "comment": "The word literally means 'not even once', which might be a good recommendation about fixing Romanian mojibake",
+        "original": "NICIODATĂ\u00a0",
+        "fixed": "NICIODATĂ\u00a0",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: Be careful around curly apostrophes",
+        "comment": "It shouldn't end up saying 'a lot of Òs'",
+        "original": "There are a lot of Ã’s in mojibake text",
+        "fixed-encoding": "There are a lot of Ã’s in mojibake text",
+        "fixed": "There are a lot of Ã's in mojibake text",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: Romanian word before a trademark sign",
+        "comment": "We would change 'DATÃ™' to 'DATÙ' if it passed the badness heuristic",
+        "original": "NICIODATĂ™",
+        "fixed": "NICIODATĂ™",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: Lithuanian word before a trademark sign",
+        "comment": "Similar to the above example. Shouldn't turn into U+0619 ARABIC SMALL DAMMA",
+        "original": "TRANSFORMATORIŲ™",
+        "fixed": "TRANSFORMATORIŲ™",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: Norwegian capitalized nonsense",
+        "comment": "We're shouting that the island of Håøya is gullible. It should not turn into 'HŨYA ER BLŨYD'.",
+        "original": "HÅØYA ER BLÅØYD",
+        "fixed": "HÅØYA ER BLÅØYD",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: raised eyebrow kaomoji",
+        "original": "Ō¬o",
+        "fixed": "Ō¬o",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic, negative: Camel-cased Serbian that looks like a UTF-8 / Windows-1251 mixup",
+        "comment": "I made this text up, but it seems like it means 'HelloDevil'. Could be a username or something.",
+        "original": "ПоздравЂаво",
+        "fixed": "ПоздравЂаво",
+        "expect": "pass"
+    },
+    {
+        "label": "Synthetic: mojibake with trademark sign at the end of a word",
+        "comment": "I recall the correct version of this text from a sign in the movie Amélie. Now we can help her twin AmÃ©lie, who makes mojibaked signs.",
+        "original": "OÃ™ ET QUAND?",
+        "fixed": "OÙ ET QUAND?",
+        "expect": "pass"
+    }
+]

--- a/python/tests/test_api_exports.py
+++ b/python/tests/test_api_exports.py
@@ -1,0 +1,76 @@
+import plsfix
+
+
+def test_config_creation_and_usage():
+    config = plsfix.PyTextFixerConfig(
+        unescape_html=False,
+        remove_terminal_escapes=False,
+        fix_encoding=True,
+        fix_character_width=False,
+        uncurl_quotes=False,
+        remove_control_chars=False,
+        normalization=None,
+        max_decode_length=500000,
+    )
+
+    text = "Hello 'world'... ＬＯＵＤ"
+    result = plsfix.fix_text(text, config)
+    assert result == "Hello 'world'... ＬＯＵＤ"
+
+
+def test_normalization_options():
+    text = "café"
+
+    config_nfc = plsfix.PyTextFixerConfig(normalization=plsfix.PyNormalization.NFC)
+    result_nfc = plsfix.fix_text(text, config_nfc)
+    assert result_nfc == "café"
+
+    config_nfd = plsfix.PyTextFixerConfig(normalization=plsfix.PyNormalization.NFD)
+    result_nfd = plsfix.fix_text(text, config_nfd)
+    assert result_nfd == "cafe\u0301"
+
+    config_nfkc = plsfix.PyTextFixerConfig(normalization=plsfix.PyNormalization.NFKC)
+    result_nfkc = plsfix.fix_text(text, config_nfkc)
+    assert result_nfkc == "café"
+
+    config_nfkd = plsfix.PyTextFixerConfig(normalization=plsfix.PyNormalization.NFKD)
+    result_nfkd = plsfix.fix_text(text, config_nfkd)
+    assert result_nfkd == "cafe\u0301"
+
+    config_no_norm = plsfix.PyTextFixerConfig(normalization=None)
+    result = plsfix.fix_text(text, config_no_norm)
+    assert result == "café"
+
+
+def test_fix_and_explain_with_config():
+    config = plsfix.PyTextFixerConfig(fix_encoding=True, remove_control_chars=True)
+
+    text = "Hello\x00World"
+    result = plsfix.fix_and_explain(text, True, config)
+
+    assert result.text == "HelloWorld"
+    assert isinstance(result.steps, list)
+    assert len(result.steps) > 0
+
+
+def test_all_config_options():
+    """Test that all config options can be set."""
+    config = plsfix.PyTextFixerConfig(
+        unescape_html=True,
+        remove_terminal_escapes=True,
+        fix_encoding=False,
+        restore_byte_a0=False,
+        replace_lossy_sequences=False,
+        decode_inconsistent_utf8=False,
+        fix_c1_controls=True,
+        fix_latin_ligatures=True,
+        fix_character_width=True,
+        uncurl_quotes=False,
+        fix_line_breaks=True,
+        remove_control_chars=True,
+        normalization=plsfix.PyNormalization.NFKC,
+        max_decode_length=100000,
+    )
+
+    result = plsfix.fix_text("test", config)
+    assert result == "test"

--- a/python/tests/test_examples_in_json.py
+++ b/python/tests/test_examples_in_json.py
@@ -1,0 +1,57 @@
+"""
+Test ftfy's fixes using the data in `test_cases.json`.
+
+I collected many test cases by listening to the Twitter streaming API for
+millions of tweets, picking out examples with high weirdness, and seeing what
+ftfy decoded them to. There are some impressive things that can happen to text,
+even in an ecosystem that is supposedly entirely UTF-8.
+
+Some examples come from the Common Crawl (particularly those involving
+Windows-1250 mojibake, which is more common on arbitrary Web pages than on
+Twitter), and some examples marked as 'synthetic' are contrived to test
+particular features of ftfy.
+
+Each test case is a dictionary containing the following items:
+
+- "label": a label that will identify the test case in nosetests
+- "original": the text to be ftfy'd
+- "fixed": what the result of ftfy.fix_text should be on this text
+
+There are also two optional fields:
+
+- "fixed-encoding": what the result of just ftfy.fix_encoding should be.
+  If missing, it will be considered to be the same as "fixed".
+- "comment": possibly-enlightening commentary on the test case.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import plsfix
+
+THIS_DIR = Path(__file__).parent
+TEST_CASE_DIR = THIS_DIR / "test-cases"
+
+
+def load_test_data() -> list[dict]:
+    test_data = []
+    for filepath in TEST_CASE_DIR.glob("*.json"):
+        test_data.extend(json.load(filepath.open()))
+    return test_data
+
+
+TEST_DATA = load_test_data()
+
+TESTS_THAT_PASS = [test for test in TEST_DATA if test["expect"] == "pass"]
+TESTS_THAT_FAIL = [test for test in TEST_DATA if test["expect"] == "fail"]
+
+
+@pytest.mark.parametrize("test_case", TEST_DATA)
+def test_well_formed_example(test_case):
+    assert test_case["expect"] in ("pass", "fail")
+
+
+
+


### PR DESCRIPTION
Expose following through Python api.

- `PyTextFixerConfig`
- `PyExplainedText`
- `PyExplanationStep`
- `PyNormalization`

Also ported over unit tests from `ftfy`

I wasnt able to set some arguments from python, so I thought this would be necessary. Pls let me know if there is a way with the current version
